### PR TITLE
[AE-664] Add Provide tag for libhdfs to resolve yum dependency check

### DIFF
--- a/scripts/justinstall.sh
+++ b/scripts/justinstall.sh
@@ -18,9 +18,6 @@ fpm --verbose \
 --maintainer ops@verticloud.com \
 --vendor VertiCloud \
 --provides ${RPM_NAME} \
---provides "libhdfs.so.0.0.0()(64bit)" \
---provides "libhdfs(x86-64)" \
---provides libhdfs \
 --description "${DESCRIPTION}" \
 --replaces vcc-fuse \
 -s dir \
@@ -71,6 +68,9 @@ fpm --verbose \
 --maintainer ops@verticloud.com \
 --vendor VertiCloud \
 --provides ${RPM_NAME} \
+--provides "libhdfs.so.0.0.0()(64bit)" \
+--provides "libhdfs(x86-64)" \
+--provides libhdfs \
 --replaces vcc-hadoop \
 --depends 'lzo > 2.0' \
 -s dir \


### PR DESCRIPTION
The major point of this is to add the Provide tag for libhdfs since it doesn't exist, and for 3rd party application such as Impala or others may require this as part of the RPM. By adding these to the fpm command, we will be able to install impala via yum and pull in the dependent RPM without manually running rpm commands.
